### PR TITLE
android: Remove separated namespaces for gralloc and libdebug

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,8 +1,6 @@
 soong_namespace {
     imports: [
         "vendor/qcom/opensource/display-commonsys-intf/sm8350",
-        "vendor/qcom/opensource/display/sm8350/gralloc",
-        "vendor/qcom/opensource/display/sm8350/libdebug",
     ]
 }
 

--- a/gralloc/Android.bp
+++ b/gralloc/Android.bp
@@ -1,10 +1,4 @@
 //libgrallocutils
-soong_namespace {
-    imports: [
-         "vendor/qcom/opensource/display-commonsys-intf/sm8350",
-         "vendor/qcom/opensource/display/sm8350",
-    ],
-}
 cc_library_shared {
     name: "libgrallocutils",
     defaults: ["qtidisplay_defaults"],

--- a/libdebug/Android.bp
+++ b/libdebug/Android.bp
@@ -1,8 +1,3 @@
-soong_namespace {
-    imports: [
-        "vendor/qcom/opensource/display/sm8350",
-    ],
-}
 cc_library_shared {
 
     name: "libdisplaydebug",


### PR DESCRIPTION
These namespaces are required to be imported explicitly through `PRODUCT_SOONG_NAMESPACES` for the targets to be made available to makefiles and in particular `PRODUCT_PACKAGES` - otherwise no gralloc mapper nor allocator ends up on the device.  By removing these namespaces we rely on the `vendor/qcom/opensource/display/sm8350` namespace one level up to guard these binaries just like all other display stacks.

@jerpelea please revert/drop https://github.com/sonyxperiadev/device-sony-common/commit/c35aa454b4500372b30895bad49a1badf1d12110 now that this proper fix is available.
