### PR TITLE
Android.mk: Put qmcs image behind sm8350 platform filter

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,2 +1,4 @@
 LOCAL_PATH := $(call my-dir)
+ifeq ($(filter sm8350,$(TARGET_BOARD_PLATFORM)),)
 include $(LOCAL_PATH)/qmcs.mk
+endif


### PR DESCRIPTION
qmcs is a new Display partition that has been added in Lahaina SoC (Sagami platform for us).

Thus we do not need to generate this image for other platforms as it serves no purpose.

Source: [40afb6f4f07e5036a8547765f8352775128614dc](https://github.com/sonyxperiadev/vendor-qcom-opensource-display/commit/40afb6f4f07e5036a8547765f8352775128614dc)