### PR TITLE
[9.12.r1] Changes for legacy mm-camera framework

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -39,6 +39,10 @@ ifeq ($(LLVM_SA), true)
     common_flags += --compile-and-analyze --analyzer-perf --analyzer-Werror
 endif
 
+ifneq (,$(filter sdm660 $(TRINKET), $(TARGET_BOARD_PLATFORM)))
+    common_flags += -DTARGET_LEGACY_CAMERA
+endif
+
 #Common libraries external to display HAL
 common_libs := liblog libutils libcutils libhardware
 common_deps  :=

--- a/gralloc/gr_utils.cpp
+++ b/gralloc/gr_utils.cpp
@@ -153,7 +153,8 @@ bool IsCompressedRGBFormat(int format) {
   return false;
 }
 
-bool IsCameraCustomFormat(int format, uint64_t usage) {
+bool IsCameraCustomFormat([[maybe_unused]] int format, [[maybe_unused]] uint64_t usage) {
+#ifndef TARGET_LEGACY_CAMERA
   switch (format) {
     case HAL_PIXEL_FORMAT_NV21_ZSL:
     case HAL_PIXEL_FORMAT_NV12_LINEAR_FLEX:
@@ -174,6 +175,7 @@ bool IsCameraCustomFormat(int format, uint64_t usage) {
     default:
       break;
   }
+#endif
 
   return false;
 }

--- a/gralloc/gr_utils.cpp
+++ b/gralloc/gr_utils.cpp
@@ -153,7 +153,7 @@ bool IsCompressedRGBFormat(int format) {
   return false;
 }
 
-bool IsCameraCustomFormat(int format) {
+bool IsCameraCustomFormat(int format, uint64_t usage) {
   switch (format) {
     case HAL_PIXEL_FORMAT_NV21_ZSL:
     case HAL_PIXEL_FORMAT_NV12_LINEAR_FLEX:
@@ -165,6 +165,11 @@ bool IsCameraCustomFormat(int format) {
     case HAL_PIXEL_FORMAT_RAW_OPAQUE:
     case HAL_PIXEL_FORMAT_RAW10:
     case HAL_PIXEL_FORMAT_RAW12:
+      if (usage & GRALLOC_USAGE_HW_COMPOSER) {
+        ALOGW("%s: HW_Composer flag is set for camera custom format: 0x%x, Usage: 0x%" PRIx64,
+              __FUNCTION__, format, usage);
+        return false;
+      }
       return true;
     default:
       break;
@@ -304,7 +309,7 @@ unsigned int GetSize(const BufferInfo &info, unsigned int alignedw, unsigned int
     return 0;
   }
 
-  if (IsCameraCustomFormat(format) && CameraInfo::GetInstance()) {
+  if (IsCameraCustomFormat(format, usage) && CameraInfo::GetInstance()) {
     int result = CameraInfo::GetInstance()->GetBufferSize(format, width, height, &size);
     if (result != 0) {
       ALOGE("%s: Failed to get the buffer size through camera library. Error code: %d",
@@ -393,6 +398,9 @@ unsigned int GetSize(const BufferInfo &info, unsigned int alignedw, unsigned int
         size = VENUS_BUFFER_SIZE(COLOR_FMT_NV12_512, width, height);
         break;
 #endif
+      case HAL_PIXEL_FORMAT_NV21_ZSL:
+        size = ALIGN((alignedw * alignedh) + (alignedw * alignedh) / 2, SIZE_4K);
+        break;
       default:ALOGE("%s: Unrecognized pixel format: 0x%x", __FUNCTION__, format);
         return 0;
     }
@@ -551,6 +559,10 @@ void GetYuvSPPlaneInfo(const BufferInfo &info, int format, uint32_t width, uint3
       c_size = c_stride * c_height;
       break;
 #endif
+    case HAL_PIXEL_FORMAT_NV21_ZSL:
+      c_size = (width * height) / 2;
+      c_height = height >> 1;
+      break;
     case HAL_PIXEL_FORMAT_Y16:
       c_size = c_stride = 0;
       c_height = 0;
@@ -1015,7 +1027,7 @@ void GetAlignedWidthAndHeight(const BufferInfo &info, unsigned int *alignedw,
   // Use of aligned width and aligned height is to calculate the size of buffer,
   // but in case of camera custom format size is being calculated from given width
   // and given height.
-  if (IsCameraCustomFormat(format) && CameraInfo::GetInstance()) {
+  if (IsCameraCustomFormat(format, usage) && CameraInfo::GetInstance()) {
     int aligned_w = width;
     int aligned_h = height;
     int result = CameraInfo::GetInstance()->GetStrideInBytes(
@@ -1146,6 +1158,10 @@ void GetAlignedWidthAndHeight(const BufferInfo &info, unsigned int *alignedw,
       aligned_h = INT(VENUS_Y_SCANLINES(COLOR_FMT_NV12_512, height));
       break;
 #endif
+    case HAL_PIXEL_FORMAT_NV21_ZSL:
+      aligned_w = ALIGN(width, 64);
+      aligned_h = ALIGN(height, 64);
+      break;
     default:
       break;
   }
@@ -1427,7 +1443,7 @@ int GetYUVPlaneInfo(const BufferInfo &info, int32_t format, int32_t width, int32
   unsigned int y_stride, c_stride, y_height, c_height, y_size, c_size;
   uint64_t yOffset, cOffset, crOffset, cbOffset;
   int h_subsampling = 0, v_subsampling = 0;
-  if (IsCameraCustomFormat(format) && CameraInfo::GetInstance()) {
+  if (IsCameraCustomFormat(format, info.usage) && CameraInfo::GetInstance()) {
     int result = CameraInfo::GetInstance()->GetCameraFormatPlaneInfo(
         format, info.width, info.height, plane_count, plane_info);
     if (result != 0) {
@@ -1451,6 +1467,7 @@ int GetYUVPlaneInfo(const BufferInfo &info, int32_t format, int32_t width, int32
     case HAL_PIXEL_FORMAT_YCrCb_422_SP:
     case HAL_PIXEL_FORMAT_YCrCb_420_SP_ADRENO:
     case HAL_PIXEL_FORMAT_YCrCb_420_SP_VENUS:
+    case HAL_PIXEL_FORMAT_NV21_ZSL:
       *plane_count = 2;
       GetYuvSPPlaneInfo(info, format, width, height, 1, plane_info);
       GetYuvSubSamplingFactor(format, &h_subsampling, &v_subsampling);
@@ -1684,6 +1701,7 @@ void GetYuvSubSamplingFactor(int32_t format, int *h_subsampling, int *v_subsampl
     case HAL_PIXEL_FORMAT_NV21_ENCODEABLE:
     case HAL_PIXEL_FORMAT_YV12:
     case HAL_PIXEL_FORMAT_NV12_HEIF:
+    case HAL_PIXEL_FORMAT_NV21_ZSL:
       *h_subsampling = 1;
       *v_subsampling = 1;
       break;

--- a/gralloc/gr_utils.h
+++ b/gralloc/gr_utils.h
@@ -197,7 +197,7 @@ bool IsUBwcFormat(int format);
 bool IsUBwcSupported(int format);
 bool IsUBwcPISupported(int format, uint64_t usage);
 bool IsUBwcEnabled(int format, uint64_t usage);
-bool IsCameraCustomFormat(int format);
+bool IsCameraCustomFormat(int format, uint64_t usage);
 void GetYuvUBwcWidthAndHeight(int width, int height, int format, unsigned int *aligned_w,
                               unsigned int *aligned_h);
 void GetYuvSPPlaneInfo(const BufferInfo &info, int format, uint32_t width, uint32_t height,


### PR DESCRIPTION
- The new buffer allocation mechanism introduced in commit https://github.com/sonyxperiadev/vendor-qcom-opensource-display/commit/1ff363db0351d53d2295a7fb0b3995900fcd334f
("gralloc: Add buffer allocation support for camera utils format.") is
completely depends on the CamX framework and is not available when using
the legacy mm-camera. Prevent this mechanism from being used on SoCs
(SDM660 and Trinket) that use legacy camera framework.
- Restored ZSL pixel format calculation in gralloc.