### PR TITLE
[DISPLAY.LA.2.0.r1] Remove vmmem

### DIFF
--- a/gralloc/Android.bp
+++ b/gralloc/Android.bp
@@ -49,7 +49,6 @@ cc_library_shared {
         "qti_kernel_headers",
         "qti_display_kernel_headers",
         "device_kernel_headers",
-        "libvmmem_headers",
     ],
     include_dirs: [
         "system/memory/libion/include",

--- a/gralloc/Android.bp
+++ b/gralloc/Android.bp
@@ -64,7 +64,6 @@ cc_library_shared {
         "libhidlbase",
         "libion",
         "libdmabufheap",
-        "libvmmem",
         "android.hardware.graphics.mapper@2.1",
         "android.hardware.graphics.mapper@3.0",
         "android.hardware.graphics.mapper@4.0",

--- a/gralloc/gr_dma_mgr.cpp
+++ b/gralloc/gr_dma_mgr.cpp
@@ -179,24 +179,18 @@ int DmaManager::UnmapBuffer(void *base, unsigned int size, unsigned int /*offset
 
 int DmaManager::SecureMemPerms(AllocData *data) {
   int ret = 0;
+  // Disable libvmmem calls until library is added to QIIFA CMD
+  /*
   std::unique_ptr<VmMem> vmmem = VmMem::CreateVmMem();
-  if (!vmmem) {
-    return -ENOMEM;
-  }
   VmPerm vm_perms;
 
   for (auto vm_name : data->vm_names) {
     VmHandle handle = vmmem->FindVmByName(vm_name);
-    if (vm_name == "qcom,cp_sec_display" || vm_name == "qcom,cp_camera_preview") {
-      vm_perms.push_back(std::make_pair(handle, VMMEM_READ));
-    } else if (vm_name == "qcom,cp_cdsp") {
-      vm_perms.push_back(std::make_pair(handle, VMMEM_READ | VMMEM_WRITE | VMMEM_EXEC));
-    } else {
-      vm_perms.push_back(std::make_pair(handle, VMMEM_READ | VMMEM_WRITE));
-    }
+    vm_perms.push_back(std::make_pair(handle, VMMEM_READ | VMMEM_WRITE));
   }
 
   ret = vmmem->LendDmabuf(data->fd, vm_perms);
+  */
   return ret;
   }
 

--- a/gralloc/gr_dma_mgr.h
+++ b/gralloc/gr_dma_mgr.h
@@ -31,7 +31,6 @@
 #define __GR_DMA_MGR_H__
 
 #include <BufferAllocator/BufferAllocator.h>
-#include <vmmem.h>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Since vmmem is a proprietary library and we cant build it as it is
lets remove all commits that introduced it.

The actual code that the library touched was commented out before
and it worked.