### PR TITLE
Android.bp: Rename changed shared libraries

### DIFF
--- a/composer/Android.bp
+++ b/composer/Android.bp
@@ -65,8 +65,8 @@ cc_binary {
         "libdisplayconfig.qti",
         "libdrm",
         "libbinder_ndk",
-        "android.hardware.common-V2-ndk_platform",
-        "vendor.qti.hardware.display.config-V5-ndk_platform",
+        "android.hardware.common-V2-ndk",
+        "vendor.qti.hardware.display.config-V5-ndk",
         "vendor.qti.hardware.display.demura@2.0",
     ],
 


### PR DESCRIPTION
Looks like that in Android 13 these libraries had their _platform postfix removed.

This fixes the build error.

Keep in mind that while this fixes this issue on A13 it has to be tested on
A12 and its very likely it may not work there.

This may be solvable in better way with GO. Thats why im marking it as DRAFT.