### PR TITLE
[9.12] Drop deprecated `clang: true` property from `Android.bp`

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -16,7 +16,6 @@ cc_defaults {
         "libutils",
     ],
     header_libs: ["display_headers"],
-    clang: true,
 }
 
 cc_library_headers {


### PR DESCRIPTION
All C(++) code in Android now builds with `clang`, setting this property no longer has effect nor meaning.

https://android.googlesource.com/platform/build/+/master/Changes.md#stop-using-clang-property
