### PR TITLE
[9.14] Drop deprecated `clang: true` property from `Android.bp`

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -34,7 +34,6 @@ qtidisplay_cc_defaults {
         "libcutils",
         "libutils",
     ],
-    clang: true,
     soong_config_variables: {
         drmpp: {
             cflags: ["-DPP_DRM_ENABLE"],

--- a/composer/Android.bp
+++ b/composer/Android.bp
@@ -19,7 +19,6 @@ cc_binary {
         "-Wno-unused-parameter",
         "-DLOG_TAG=\"SDM\"",
     ],
-    clang: true,
 
     shared_libs: [
         "libbinder",

--- a/hdmi_cec/Android.bp
+++ b/hdmi_cec/Android.bp
@@ -22,7 +22,6 @@ cc_library_shared {
         "-DLOG_TAG=\"qdhdmi_cec\"",
         "-Wno-sign-conversion",
     ],
-    clang: true,
     srcs: [
         "qhdmi_cec.cpp",
         "QHDMIClient.cpp",

--- a/libdebug/Android.bp
+++ b/libdebug/Android.bp
@@ -15,6 +15,5 @@ cc_library_shared {
         "-fno-operator-names",
     ],
     export_include_dirs: ["."],
-    clang: true,
     srcs: ["debug_handler.cpp"],
 }

--- a/libdrmutils/Android.bp
+++ b/libdrmutils/Android.bp
@@ -21,7 +21,6 @@ cc_library_shared {
         "-Werror",
         "-fno-operator-names",
     ],
-    clang: true,
 
     srcs: [
         "drm_master.cpp",

--- a/libhistogram/Android.bp
+++ b/libhistogram/Android.bp
@@ -37,7 +37,6 @@ cc_library_shared {
         "-fno-operator-names",
         "-Wthread-safety",
     ],
-    clang: true,
     srcs: [
         "histogram_collector.cpp",
         "ringbuffer.cpp",
@@ -70,7 +69,6 @@ cc_binary {
         "-fno-operator-names",
         "-Wthread-safety",
     ],
-    clang: true,
 
     vendor: true,
 
@@ -105,7 +103,6 @@ cc_binary {
         "-fno-operator-names",
         "-Wthread-safety",
     ],
-    clang: true,
 
     vendor: true,
 

--- a/liblight/Android.bp
+++ b/liblight/Android.bp
@@ -1,4 +1,3 @@
-
 cc_library_shared {
     name: "lights.qcom",
     srcs: ["lights.c"],
@@ -6,7 +5,5 @@ cc_library_shared {
     header_libs: ["libhardware_headers"],
     shared_libs: ["liblog"],
     cflags: ["-DLOG_TAG=\"qdlights\""],
-    clang: true,
     vendor: true,
-
 }

--- a/libmemtrack/Android.bp
+++ b/libmemtrack/Android.bp
@@ -9,7 +9,6 @@ cc_library_shared {
         "-Werror",
         "-Wno-sign-conversion",
     ],
-    clang: true,
     shared_libs: ["liblog"],
     header_libs: ["libhardware_headers"],
     srcs: [

--- a/libmemutils/Android.bp
+++ b/libmemutils/Android.bp
@@ -22,7 +22,6 @@ cc_library_shared {
         "-Wno-unused-parameter",
         "-DLOG_TAG=\"MEM-UTILS\"",
     ],
-    clang: true,
     srcs: [
         "membuf_wrapper.cpp",
     ],

--- a/qmaa/Android.bp
+++ b/qmaa/Android.bp
@@ -24,7 +24,6 @@ cc_binary {
         "-Wno-unused-parameter",
         "-DLOG_TAG=\"SDM\"",
     ],
-    clang: true,
 
     shared_libs: [
         "libbinder",

--- a/sde-drm/Android.bp
+++ b/sde-drm/Android.bp
@@ -24,7 +24,6 @@ cc_library_shared {
         "-Wno-unused-parameter",
         "-DLOG_TAG=\"SDE_DRM\"",
     ],
-    clang: true,
     srcs: [
         "drm_manager.cpp",
         "drm_connector.cpp",


### PR DESCRIPTION
All C(++) code in Android now builds with `clang`, setting this property no longer has effect nor meaning.

https://android.googlesource.com/platform/build/+/master/Changes.md#stop-using-clang-property
