### PR TITLE
[DISPLAY.LA.2.0] Drop deprecated `clang: true` property from `Android.bp`

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -85,7 +85,6 @@ qtidisplay_cc_defaults {
         "libcutils",
         "libutils",
     ],
-    clang: true,
     soong_config_variables: {
         drmpp: {
             cflags: ["-DPP_DRM_ENABLE"],

--- a/composer/Android.bp
+++ b/composer/Android.bp
@@ -23,7 +23,6 @@ cc_binary {
         "-Wno-format",
         "-DLOG_TAG=\"SDM\"",
     ],
-    clang: true,
 
     shared_libs: [
         "libbinder",

--- a/hdmi_cec/Android.bp
+++ b/hdmi_cec/Android.bp
@@ -23,7 +23,6 @@ cc_library_shared {
         "-DLOG_TAG=\"qdhdmi_cec\"",
         "-Wno-sign-conversion",
     ],
-    clang: true,
     srcs: [
         "qhdmi_cec.cpp",
         "QHDMIClient.cpp",

--- a/libdebug/Android.bp
+++ b/libdebug/Android.bp
@@ -15,6 +15,5 @@ cc_library_shared {
         "-fno-operator-names",
     ],
     export_include_dirs: ["."],
-    clang: true,
     srcs: ["debug_handler.cpp"],
 }

--- a/libdrmutils/Android.bp
+++ b/libdrmutils/Android.bp
@@ -23,7 +23,6 @@ cc_library_shared {
         "-Werror",
         "-fno-operator-names",
     ],
-    clang: true,
 
     srcs: [
         "drm_master.cpp",

--- a/libhistogram/Android.bp
+++ b/libhistogram/Android.bp
@@ -38,7 +38,6 @@ cc_library_shared {
         "-fno-operator-names",
         "-Wthread-safety",
     ],
-    clang: true,
     srcs: [
         "histogram_collector.cpp",
         "ringbuffer.cpp",
@@ -72,7 +71,6 @@ cc_binary {
         "-fno-operator-names",
         "-Wthread-safety",
     ],
-    clang: true,
 
     vendor: true,
 
@@ -108,7 +106,6 @@ cc_binary {
         "-fno-operator-names",
         "-Wthread-safety",
     ],
-    clang: true,
 
     vendor: true,
 

--- a/liblight/Android.bp
+++ b/liblight/Android.bp
@@ -1,4 +1,3 @@
-
 cc_library_shared {
     name: "lights.qcom",
     srcs: ["lights.c"],
@@ -6,7 +5,5 @@ cc_library_shared {
     header_libs: ["libhardware_headers"],
     shared_libs: ["liblog"],
     cflags: ["-DLOG_TAG=\"qdlights\""],
-    clang: true,
     vendor: true,
-
 }

--- a/oem_services/Android.bp
+++ b/oem_services/Android.bp
@@ -16,7 +16,6 @@ cc_library_shared {
         "-Wno-unused-parameter",
         "-DLOG_TAG=\"SDM\"",
     ],
-    clang: true,
     header_libs: ["display_headers"],
 
     shared_libs: [
@@ -52,7 +51,6 @@ cc_binary {
         "-Wno-unused-parameter",
         "-DLOG_TAG=\"SDM\"",
     ],
-    clang: true,
 
     header_libs: ["display_headers"],
 

--- a/qmaa/Android.bp
+++ b/qmaa/Android.bp
@@ -26,7 +26,6 @@ cc_binary {
         "-Wno-unused-parameter",
         "-DLOG_TAG=\"SDM\"",
     ],
-    clang: true,
 
     shared_libs: [
         "libbinder",

--- a/sde-drm/Android.bp
+++ b/sde-drm/Android.bp
@@ -25,7 +25,6 @@ cc_library_shared {
         "-Wno-unused-parameter",
         "-DLOG_TAG=\"SDE_DRM\"",
     ],
-    clang: true,
     srcs: [
         "drm_manager.cpp",
         "drm_connector.cpp",


### PR DESCRIPTION
All C(++) code in Android now builds with `clang`, setting this property no longer has effect nor meaning.

https://android.googlesource.com/platform/build/+/master/Changes.md#stop-using-clang-property
