### PR TITLE
[DISPLAY.LA.3.0.r1] Build fix patches

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,5 +1,5 @@
 soong_namespace {
-    imports: ["vendor/qcom/opensource/display-commonsys-intf/sm8450"],
+    imports: ["vendor/qcom/opensource/display-commonsys-intf/sm8550"],
 }
 
 soong_config_module_type {

--- a/composer/hwc_session_services.cpp
+++ b/composer/hwc_session_services.cpp
@@ -1186,8 +1186,6 @@ bool HWCSession::CWB::IsCwbActiveOnDisplay(hwc2_display_t disp_type) {
     dpy_index = hwc_session_->GetDisplayIndex(qdutils::DISPLAY_PRIMARY);
   } else if (disp_type == HWC_DISPLAY_EXTERNAL) {
     dpy_index = hwc_session_->GetDisplayIndex(qdutils::DISPLAY_EXTERNAL);
-  } else if (disp_type == HWC_DISPLAY_BUILTIN_2) {
-    dpy_index = hwc_session_->GetDisplayIndex(qdutils::DISPLAY_BUILTIN_2);
   } else {
     return false;
   }

--- a/gralloc/Android.bp
+++ b/gralloc/Android.bp
@@ -28,6 +28,8 @@ cc_library_shared {
         "-Wno-sign-conversion",
         "-Wno-unused-parameter",
         "-Wno-unused-variable",
+        "-Wno-format",
+        "-Wno-implicit-fallthrough",
     ],
     srcs: [
         "gr_utils.cpp",
@@ -71,6 +73,7 @@ cc_library_shared {
         "-Wno-sign-conversion",
         "-Wno-unused-variable",
         "-Wno-unused-parameter",
+        "-Wno-format",
     ],
     srcs: [
         "gr_allocator.cpp",
@@ -141,6 +144,7 @@ cc_library_shared {
         "-DLOG_TAG=\"qdgralloc\"",
         "-D__QTI_DISPLAY_GRALLOC__",
         "-Wno-sign-conversion",
+        "-Wno-unused-parameter",
     ],
     srcs: [
         "QtiMapper4.cpp",
@@ -182,6 +186,7 @@ cc_binary {
     cflags: [
         "-DLOG_TAG=\"qdgralloc\"",
         "-D__QTI_DISPLAY_GRALLOC__",
+        "-Wno-unused-parameter",
     ],
     srcs: [
         "QtiAllocator.cpp",

--- a/gralloc/Android.bp
+++ b/gralloc/Android.bp
@@ -9,6 +9,7 @@ cc_library_shared {
 
     header_libs: [
         "display_headers",
+        "display_intf_headers",
         "qti_kernel_headers",
         "device_kernel_headers",
     ],
@@ -48,6 +49,7 @@ cc_library_shared {
     vendor: true,
     header_libs: [
         "display_headers",
+        "display_intf_headers",
         "qti_kernel_headers",
         "device_kernel_headers",
     ],

--- a/qmaa/Android.bp
+++ b/qmaa/Android.bp
@@ -1,7 +1,7 @@
 soong_namespace {
     imports: [
-        "vendor/qcom/opensource/display/sm8450",
-        "vendor/qcom/opensource/display/sm8450/libdebug",
+        "vendor/qcom/opensource/display/sm8550",
+        "vendor/qcom/opensource/display/sm8550/libdebug",
     ],
 }
 composer_srcs = ["*.cpp"]

--- a/sdm/libs/dal/Android.bp
+++ b/sdm/libs/dal/Android.bp
@@ -8,6 +8,7 @@ cc_library_shared {
     cflags: [
         "-fno-operator-names",
         "-Wno-unused-parameter",
+        "-Wno-format",
         "-DLOG_TAG=\"SDM\"",
     ],
     shared_libs: [

--- a/sdm/libs/dal/Android.bp
+++ b/sdm/libs/dal/Android.bp
@@ -11,6 +11,10 @@ cc_library_shared {
         "-Wno-format",
         "-DLOG_TAG=\"SDM\"",
     ],
+    header_libs: [
+        "display_headers",
+        "qti_kernel_headers",
+    ],
     shared_libs: [
         "libdisplaydebug",
         "libsdmutils",


### PR DESCRIPTION
The minimum set of changes required for compilation.

The display HAL requires blobs that match the current tag!
Otherwise we will have to revert https://github.com/sonyxperiadev/vendor-qcom-opensource-display/commit/c8c0572ef190473ecbadba4b209667c6fa0d2611 commit and add `IsDisplayHWAvailable()` stub function for `ResourceInterface` or prevent it calling in `CompManager::IsDisplayHWAvailable()`.