### PR TITLE
[DISPLAY.LA.3.0.r1] Avoid Resource Manager IsDisplayHWAvailable() function call

### DIFF
--- a/sdm/include/private/resource_interface.h
+++ b/sdm/include/private/resource_interface.h
@@ -143,7 +143,7 @@ class ResourceInterface {
   virtual uint32_t GetMixerCount() = 0;
   virtual void HandleTUITransition(Handle display_ctx, bool tui_active) = 0;
   virtual DisplayError SetBlendSpace(Handle display_ctx, const PrimariesTransfer &blend_space) = 0;
-  virtual bool IsDisplayHWAvailable() { return true; }
+  virtual bool IsDisplayHWAvailable() = 0;
 };
 
 }  // namespace sdm

--- a/sdm/libs/core/comp_manager.cpp
+++ b/sdm/libs/core/comp_manager.cpp
@@ -813,7 +813,8 @@ bool CompManager::IsRotatorSupportedFormat(LayerBufferFormat format) {
 bool CompManager::IsDisplayHWAvailable() {
   std::lock_guard<std::recursive_mutex> obj(comp_mgr_mutex_);
   if (resource_intf_) {
-    return resource_intf_->IsDisplayHWAvailable();
+    //return resource_intf_->IsDisplayHWAvailable();
+    return true;
   }
 
   return false;


### PR DESCRIPTION
Second attempt.
Leave the Resource Manager interface untouched with pure virtual functions. Instead of calling the RM IsDisplayHWAvailable() function, return the expected result.
Tested with current blobs on PDX-234 (1V).