### PR TITLE
[2.0.r1] gralloc: Ignore implicit-fallthrough warnings

### DIFF
--- a/gralloc/Android.bp
+++ b/gralloc/Android.bp
@@ -29,6 +29,7 @@ cc_library_shared {
         "-Wno-sign-conversion",
         "-Wno-unused-parameter",
         "-Wno-unused-variable",
+        "-Wno-implicit-fallthrough",
     ],
     srcs: [
         "gr_utils.cpp",


### PR DESCRIPTION
Ignore implicit-fallthrough compilation warnings. The code
is a bit messy and for the portability of our patches we
decided not to fix all the compilation warnings, but to
ignore them.