### PR TITLE
[DISPLAY.LA.3.0.r1] Bump vendor.qti.hardware.display.config to v5

### DIFF
--- a/composer/Android.bp
+++ b/composer/Android.bp
@@ -61,7 +61,7 @@ cc_binary {
         "libdrm",
         "libbinder_ndk",
         "android.hardware.common-V2-ndk",
-        "vendor.qti.hardware.display.config-V4-ndk",
+        "vendor.qti.hardware.display.config-V5-ndk",
         "vendor.qti.hardware.display.demura@2.0",
         "vendor.qti.hardware.display.mapperextensions@1.1",
         "vendor.qti.hardware.display.mapperextensions@1.2",

--- a/composer/hwc_display.cpp
+++ b/composer/hwc_display.cpp
@@ -3675,6 +3675,13 @@ void HWCDisplay::NotifyCwbDone(int32_t status, const LayerBuffer& buffer) {
            status);
 }
 
+DisplayError HWCDisplay::NotifyFpsMitigation(const float fps,
+                                             DisplayConcurrencyType concurrency,
+                                             bool concurrency_begin) {
+  event_handler_->NotifyConcurrencyFps(fps, concurrency, concurrency_begin);
+  return kErrorNone;
+}
+
 void HWCDisplay::Abort() {
   display_intf_->Abort();
 }

--- a/composer/hwc_display.h
+++ b/composer/hwc_display.h
@@ -502,6 +502,8 @@ class HWCDisplay : public DisplayEventHandler {
   virtual DisplayError HandleEvent(DisplayEvent event);
   virtual DisplayError HandleQsyncState(const QsyncEventData &qsync_data);
   virtual void NotifyCwbDone(int32_t status, const LayerBuffer& buffer);
+  virtual DisplayError NotifyFpsMitigation(const float fps, DisplayConcurrencyType concurrency,
+                                           bool concurrency_begin);
   virtual void DumpOutputBuffer(const BufferInfo &buffer_info, void *base,
                                 shared_ptr<Fence> &retire_fence);
   virtual HWC2::Error PrepareLayerStack(uint32_t *out_num_types, uint32_t *out_num_requests);

--- a/composer/hwc_display_event_handler.h
+++ b/composer/hwc_display_event_handler.h
@@ -37,6 +37,8 @@
 #ifndef __HWC_DISPLAY_EVENT_HANDLER_H__
 #define __HWC_DISPLAY_EVENT_HANDLER_H__
 
+#include <core/core_interface.h>
+
 namespace sdm {
 
 class HWCDisplayEventHandler {
@@ -46,6 +48,8 @@ class HWCDisplayEventHandler {
                                     uint32_t refresh_rate, uint32_t qsync_refresh_rate) = 0;
   virtual void VmReleaseDone(hwc2_display_t display) = 0;
   virtual int NotifyCwbDone(int dpy_index, int32_t status, uint64_t handle_id) = 0;
+  virtual void NotifyConcurrencyFps(const float fps, DisplayConcurrencyType concurrency,
+                                    bool concurrency_begin) = 0;
 
  protected:
   virtual ~HWCDisplayEventHandler() {}

--- a/composer/hwc_display_virtual.cpp
+++ b/composer/hwc_display_virtual.cpp
@@ -84,10 +84,11 @@ void HWCDisplayVirtual::Destroy(HWCDisplay *hwc_display) {
 }
 
 HWCDisplayVirtual::HWCDisplayVirtual(CoreInterface *core_intf, HWCBufferAllocator *buffer_allocator,
-                                     HWCCallbacks *callbacks, hwc2_display_t id, int32_t sdm_id,
-                                     uint32_t width, uint32_t height) :
-      HWCDisplay(core_intf, buffer_allocator, callbacks, nullptr, nullptr, kVirtual, id, sdm_id,
-                 DISPLAY_CLASS_VIRTUAL), width_(width), height_(height)  {
+                                     HWCCallbacks *callbacks, HWCDisplayEventHandler *event_handler,
+                                     hwc2_display_t id, int32_t sdm_id, uint32_t width,
+                                     uint32_t height) :
+      HWCDisplay(core_intf, buffer_allocator, callbacks, event_handler, nullptr, kVirtual, id,
+                 sdm_id, DISPLAY_CLASS_VIRTUAL), width_(width), height_(height)  {
 }
 
 int HWCDisplayVirtual::Init() {

--- a/composer/hwc_display_virtual.h
+++ b/composer/hwc_display_virtual.h
@@ -89,8 +89,8 @@ class HWCDisplayVirtual : public HWCDisplay {
                                       uint32_t *out_num_types, uint32_t *out_num_requests,
                                       bool *needs_commit);
   HWCDisplayVirtual(CoreInterface *core_intf, HWCBufferAllocator *buffer_allocator,
-                    HWCCallbacks *callbacks, hwc2_display_t id, int32_t sdm_id,
-                    uint32_t width, uint32_t height);
+                    HWCCallbacks *callbacks, HWCDisplayEventHandler *event_handler,
+                    hwc2_display_t id, int32_t sdm_id, uint32_t width, uint32_t height);
 
  protected:
   uint32_t width_ = 0;

--- a/composer/hwc_display_virtual_dpu.cpp
+++ b/composer/hwc_display_virtual_dpu.cpp
@@ -35,9 +35,11 @@ namespace sdm {
 
 HWCDisplayVirtualDPU::HWCDisplayVirtualDPU(CoreInterface *core_intf, HWCBufferAllocator
                                            *buffer_allocator, HWCCallbacks *callbacks,
+                                           HWCDisplayEventHandler *event_handler,
                                            hwc2_display_t id, int32_t sdm_id, uint32_t width,
                                            uint32_t height, float min_lum, float max_lum)
-  : HWCDisplayVirtual(core_intf, buffer_allocator, callbacks, id, sdm_id, width, height),
+  : HWCDisplayVirtual(core_intf, buffer_allocator, callbacks, event_handler, id, sdm_id,
+                      width, height),
     min_lum_(min_lum), max_lum_(max_lum) {
 }
 

--- a/composer/hwc_display_virtual_dpu.h
+++ b/composer/hwc_display_virtual_dpu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2019-2021, The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -37,8 +37,9 @@ namespace sdm {
 class HWCDisplayVirtualDPU : public HWCDisplayVirtual {
  public:
   HWCDisplayVirtualDPU(CoreInterface *core_intf, HWCBufferAllocator *buffer_allocator,
-                       HWCCallbacks *callbacks, hwc2_display_t id, int32_t sdm_id,
-                       uint32_t width, uint32_t height, float min_lum, float max_lum);
+                       HWCCallbacks *callbacks, HWCDisplayEventHandler *event_handler,
+                       hwc2_display_t id, int32_t sdm_id, uint32_t width, uint32_t height,
+                       float min_lum, float max_lum);
   virtual int Init();
   virtual HWC2::Error Validate(uint32_t *out_num_types, uint32_t *out_num_requests);
   virtual HWC2::Error Present(shared_ptr<Fence> *out_retire_fence);

--- a/composer/hwc_display_virtual_factory.cpp
+++ b/composer/hwc_display_virtual_factory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2019, 2021 The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -36,9 +36,10 @@
 namespace sdm {
 
 int HWCVirtualDisplayFactory::Create(CoreInterface *core_intf, HWCBufferAllocator *buffer_allocator,
-                              HWCCallbacks *callbacks, hwc2_display_t id, int32_t sdm_id,
-                              uint32_t width, uint32_t height, int32_t *format,
-                              float min_lum, float max_lum, HWCDisplay **hwc_display) {
+                              HWCCallbacks *callbacks, HWCDisplayEventHandler *event_handler,
+                              hwc2_display_t id, int32_t sdm_id, uint32_t width, uint32_t height,
+                              int32_t *format, float min_lum, float max_lum,
+                              HWCDisplay **hwc_display) {
   int supported_virtual_displays = 0;
   DisplayError error = core_intf->GetMaxDisplaysSupported(kVirtual, &supported_virtual_displays);
   if (error != kErrorNone) {
@@ -48,12 +49,14 @@ int HWCVirtualDisplayFactory::Create(CoreInterface *core_intf, HWCBufferAllocato
 
   HWCDisplayVirtual *hwc_display_virtual = nullptr;
   if (supported_virtual_displays) {
-    hwc_display_virtual = new HWCDisplayVirtualDPU(core_intf, buffer_allocator, callbacks, id,
-                                                   sdm_id, width, height, min_lum, max_lum);
+    hwc_display_virtual = new HWCDisplayVirtualDPU(core_intf, buffer_allocator, callbacks,
+                                                   event_handler, id, sdm_id, width, height,
+                                                   min_lum, max_lum);
   } else {
     // Create GPU based virtual display.
-    hwc_display_virtual = new HWCDisplayVirtualGPU(core_intf, buffer_allocator, callbacks, id,
-                                                   sdm_id, width, height, min_lum, max_lum);
+    hwc_display_virtual = new HWCDisplayVirtualGPU(core_intf, buffer_allocator, callbacks,
+                                                   event_handler, id, sdm_id, width, height,
+                                                   min_lum, max_lum);
   }
 
   if (hwc_display_virtual == nullptr) {

--- a/composer/hwc_display_virtual_factory.h
+++ b/composer/hwc_display_virtual_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2019, 2021 The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -41,9 +41,9 @@ namespace sdm {
 class HWCVirtualDisplayFactory {
  public:
   int Create(CoreInterface *core_intf, HWCBufferAllocator *buffer_allocator,
-             HWCCallbacks *callbacks, hwc2_display_t id, int32_t sdm_id, uint32_t width,
-             uint32_t height, int32_t *format, float min_lum, float max_lum,
-             HWCDisplay **hwc_display);
+             HWCCallbacks *callbacks, HWCDisplayEventHandler *event_handler,
+             hwc2_display_t id, int32_t sdm_id, uint32_t width, uint32_t height,
+             int32_t *format, float min_lum, float max_lum, HWCDisplay **hwc_display);
   void Destroy(HWCDisplay *hwc_display);
   bool IsGPUColorConvertSupported();
 };

--- a/composer/hwc_display_virtual_gpu.cpp
+++ b/composer/hwc_display_virtual_gpu.cpp
@@ -82,9 +82,11 @@ int HWCDisplayVirtualGPU::Deinit() {
 
 HWCDisplayVirtualGPU::HWCDisplayVirtualGPU(CoreInterface *core_intf, HWCBufferAllocator
                                            *buffer_allocator, HWCCallbacks *callbacks,
+                                           HWCDisplayEventHandler *event_handler,
                                            hwc2_display_t id, int32_t sdm_id, uint32_t width,
                                            uint32_t height, float min_lum, float max_lum) :
-  HWCDisplayVirtual(core_intf, buffer_allocator, callbacks, id, sdm_id, width, height),
+  HWCDisplayVirtual(core_intf, buffer_allocator, callbacks, event_handler, id, sdm_id,
+                    width, height),
   color_convert_task_(*this) {
 }
 

--- a/composer/hwc_display_virtual_gpu.h
+++ b/composer/hwc_display_virtual_gpu.h
@@ -68,8 +68,9 @@ class HWCDisplayVirtualGPU : public HWCDisplayVirtual,
                              public SyncTask<ColorConvertTaskCode>::TaskHandler {
  public:
   HWCDisplayVirtualGPU(CoreInterface *core_intf, HWCBufferAllocator *buffer_allocator,
-                       HWCCallbacks *callbacks, hwc2_display_t id, int32_t sdm_id,
-                       uint32_t width, uint32_t height, float min_lum, float max_lum);
+                       HWCCallbacks *callbacks, HWCDisplayEventHandler *event_handler,
+                       hwc2_display_t id, int32_t sdm_id, uint32_t width, uint32_t height,
+                       float min_lum, float max_lum);
   virtual int Init();
   virtual int Deinit();
   virtual HWC2::Error Validate(uint32_t *out_num_types, uint32_t *out_num_requests);

--- a/composer/hwc_session.cpp
+++ b/composer/hwc_session.cpp
@@ -820,6 +820,65 @@ void HWCSession::PerformQsyncCallback(hwc2_display_t display, bool qsync_enabled
   callback->NotifyQsyncChange(qsync_enabled, refresh_rate, qsync_refresh_rate);
 }
 
+
+void HWCSession::NotifyConcurrencyFps(const float fps, DisplayConcurrencyType type,
+                                      bool concurrency_begin) {
+  DisplayConfigVariableInfo var_info;
+  Attributes attributes;
+  hwc2_display_t target_display = GetActiveBuiltinDisplay();
+  hwc2_config_t current_config = 0;
+
+  if(target_display >= HWCCallbacks::kNumDisplays) {
+    return;
+  }
+
+  hwc_display_[target_display]->GetActiveConfig(&current_config);
+  int error = hwc_display_[target_display]->GetDisplayAttributesForConfig(INT(current_config),
+                                                                          &var_info);
+  if(error) {
+    return;
+  }
+
+  Concurrency concurrency;
+  attributes.vsyncPeriod = (1 / fps) * 1000000;
+  attributes.xRes = var_info.x_pixels;
+  attributes.yRes = var_info.y_pixels;
+  attributes.xDpi = var_info.x_dpi;
+  attributes.yDpi = var_info.y_dpi;
+  attributes.panelType = DisplayPortType::DEFAULT;
+  attributes.isYuv = var_info.is_yuv;
+  switch (type) {
+    case DisplayConcurrencyType::kConcurrencyWfd:
+      concurrency = Concurrency::WFD;
+    break;
+      case DisplayConcurrencyType::kConcurrencyDp:
+      concurrency = Concurrency::DP;
+    break;
+      case DisplayConcurrencyType::kConcurrencyCamera:
+      concurrency = Concurrency::CAMERA;
+    break;
+      case DisplayConcurrencyType::kConcurrencyCwb:
+      concurrency = Concurrency::CWB;
+    break;
+    case DisplayConcurrencyType::kConcurrencyNone:
+    case DisplayConcurrencyType::kConcurrencyMax:
+      return;
+  }
+
+  if(concurrency_begin) {
+    NotifyFpsMitigation(target_display, attributes, concurrency);
+    callbacks_.Refresh(target_display);
+    int ret = WaitForCommitDone(target_display, kClientConcurrency);
+    if (ret != 0) {
+      DLOGE("WaitForCommitDone failed with error %d for %d", ret, kClientConcurrency);
+    }
+    return;
+  }
+
+  std::thread(&HWCSession::NotifyFpsMitigation, this,
+              target_display, attributes, concurrency).detach();
+}
+
 void HWCSession::PerformIdleStatusCallback(hwc2_display_t display) {
   std::shared_ptr<DisplayConfig::ConfigCallback> callback = idle_callback_.lock();
   if (!callback) {
@@ -1452,7 +1511,7 @@ HWC2::Error HWCSession::CreateVirtualDisplayObj(uint32_t width, uint32_t height,
         }
 
         status = virtual_display_factory_.Create(core_intf_, &buffer_allocator_, &callbacks_,
-                                                 client_id, display_id, width, height,
+                                                 this, client_id, display_id, width, height,
                                                  format, set_min_lum_, set_max_lum_, &hwc_display);
         if (!status) {
           break;

--- a/composer/hwc_session.h
+++ b/composer/hwc_session.h
@@ -78,6 +78,7 @@ using ::aidl::vendor::qti::hardware::display::config::IDisplayConfigCallback;
 using ::aidl::vendor::qti::hardware::display::config::CameraSmoothOp;
 using ::aidl::vendor::qti::hardware::display::config::Attributes;
 using ::aidl::vendor::qti::hardware::display::config::DisplayPortType;
+using ::aidl::vendor::qti::hardware::display::config::Concurrency;
 
 namespace aidl::vendor::qti::hardware::display::config {
   class DisplayConfigAIDL;
@@ -146,6 +147,7 @@ class HWCSession : hwc2_device_t, HWCUEventListener, public qClient::BnQClient,
     kClientIdlepowerCollapse,
     kClientTeardownCWB,
     kClientTrustedUI,
+    kClientConcurrency,
     kClientMax
   };
 
@@ -309,6 +311,7 @@ class HWCSession : hwc2_device_t, HWCUEventListener, public qClient::BnQClient,
                              int64_t *client_handle);
   int UnregisterCallbackClient(const int64_t client_handle);
   int NotifyResolutionChange(int32_t disp_id, Attributes& attr);
+  int NotifyFpsMitigation(int32_t disp_id, Attributes attr, Concurrency con);
 
   virtual int RegisterClientContext(std::shared_ptr<DisplayConfig::ConfigCallback> callback,
                                     DisplayConfig::ConfigInterface **intf);
@@ -321,6 +324,8 @@ class HWCSession : hwc2_device_t, HWCUEventListener, public qClient::BnQClient,
                                     uint32_t refresh_rate, uint32_t qsync_refresh_rate);
   virtual void VmReleaseDone(hwc2_display_t display);
   virtual int NotifyCwbDone(int dpy_index, int32_t status, uint64_t handle_id);
+  virtual void NotifyConcurrencyFps(const float fps, DisplayConcurrencyType concurrency,
+                                    bool concurrency_begin);
 
   int32_t SetVsyncEnabled(hwc2_display_t display, int32_t int_enabled);
   int32_t GetDozeSupport(hwc2_display_t display, int32_t *out_support);

--- a/composer/hwc_session_services.cpp
+++ b/composer/hwc_session_services.cpp
@@ -702,6 +702,17 @@ int HWCSession::NotifyResolutionChange(int32_t disp_id, Attributes& attr) {
   return 0;
 }
 
+int HWCSession::NotifyFpsMitigation(int32_t disp_id, Attributes attr, Concurrency con) {
+  std::lock_guard<decltype(callbacks_lock_)> lock_guard(callbacks_lock_);
+  for (auto const& [id, callback] : callback_clients_) {
+    if (callback) {
+      callback->notifyFpsMitigation(disp_id, attr, con);
+    }
+  }
+
+  return 0;
+}
+
 int HWCSession::RegisterCallbackClient(
         const std::shared_ptr<IDisplayConfigCallback>& callback, int64_t *client_handle) {
   std::lock_guard<decltype(callbacks_lock_)> lock_guard(callbacks_lock_);

--- a/include/display_properties.h
+++ b/include/display_properties.h
@@ -175,7 +175,7 @@
 #define ENHANCE_IDLE_TIME                    DISPLAY_PROP("enhance_idle_time")
 
 #define MMRM_FLOOR_CLK_VOTE                  DISPLAY_PROP("mmrm_floor_vote")
-
+#define DISABLE_MITIGATED_FPS                DISPLAY_PROP("disable_mitigated_fps")
 // DPPS dynamic fps
 #define ENABLE_DPPS_DYNAMIC_FPS              DISPLAY_PROP("enable_dpps_dynamic_fps")
 // Noise Layer

--- a/init/init.qti.display_boot.sh
+++ b/init/init.qti.display_boot.sh
@@ -132,6 +132,7 @@ case "$target" in
         setprop vendor.display.target.version 3
         setprop vendor.display.enable_fb_scaling 0
         setprop vendor.display.disable_cwb_idle_fallback 1
+        setprop vendor.display.disable_mitigated_fps 1
         ;;
         530|531|540)
         setprop vendor.gralloc.use_dma_buf_heaps 1
@@ -145,6 +146,7 @@ case "$target" in
         setprop vendor.display.target.version 2
         setprop vendor.display.enable_qsync_idle 1
         setprop vendor.display.disable_cwb_idle_fallback 1
+        setprop vendor.display.disable_mitigated_fps 1
         ;;
         506|547)
         # Set property for Diwali

--- a/sdm/include/core/display_interface.h
+++ b/sdm/include/core/display_interface.h
@@ -234,6 +234,28 @@ enum DisplayDrawMethod {
                               //!< on panel.
 };
 
+/*! @brief This enum represents the display concurrency type.
+    @sa DisplayInterface::GetConcurrencyFPS
+ */
+enum DisplayConcurrencyType {
+    kConcurrencyNone,
+    kConcurrencyWfd,
+    kConcurrencyDp,
+    kConcurrencyCamera,
+    kConcurrencyCwb,
+    kConcurrencyMax,
+};
+
+/*! @brief This structure defines all input parameters for ResourceConstraints. */
+struct ResourceConstraintsIn {
+  DisplayConcurrencyType concurrency_type = DisplayConcurrencyType::kConcurrencyMax;
+};
+
+/*! @brief This structure defines all output parameters for ResourceConstraints. */
+struct ResourceConstraintsOut {
+  float fps = 0;
+};
+
 /*! @brief This structure defines configuration for display dpps ad4 region of interest. */
 struct DisplayDppsAd4RoiCfg {
   uint32_t h_start;     //!< start in hotizontal direction
@@ -442,6 +464,12 @@ class DisplayEventHandler {
 
   /*! @brief Event handler to notify CWB Done */
   virtual void NotifyCwbDone(int32_t status, const LayerBuffer& buffer) { }
+
+  /*! @brief Event handler for sending concurrency fps */
+  virtual DisplayError NotifyFpsMitigation(const float fps, DisplayConcurrencyType concurrency,
+                                           bool concurrency_begin) {
+    return kErrorNone;
+  }
 
  protected:
   virtual ~DisplayEventHandler() { }

--- a/sdm/include/private/resource_interface.h
+++ b/sdm/include/private/resource_interface.h
@@ -86,6 +86,7 @@ class ResourceInterface {
     kCmdNeedsValidate,
     kCmdSetBacklightLevel,
     kCmdSetCwbBoost,
+    kCmdGetResourceConstraints,
     kCmdMax,
   };
 

--- a/sdm/libs/core/comp_manager.cpp
+++ b/sdm/libs/core/comp_manager.cpp
@@ -784,6 +784,17 @@ bool CompManager::CheckResourceState(Handle display_ctx, bool *res_exhausted,
   return res_wait_needed;
 }
 
+DisplayError CompManager::GetConcurrencyFps(DisplayConcurrencyType type, float *fps) {
+  ResourceConstraintsIn res_constraints_in;
+  res_constraints_in.concurrency_type = type;
+  ResourceConstraintsOut res_constraints_out;
+
+  auto error = resource_intf_->Perform(ResourceInterface::kCmdGetResourceConstraints,
+                                       &res_constraints_in, &res_constraints_out);
+  *fps = res_constraints_out.fps;
+  return error;
+}
+
 DisplayError CompManager::SetDrawMethod(Handle display_ctx, const DisplayDrawMethod &draw_method) {
   std::lock_guard<std::recursive_mutex> obj(comp_mgr_mutex_);
   DisplayCompositionContext *display_comp_ctx =

--- a/sdm/libs/core/comp_manager.h
+++ b/sdm/libs/core/comp_manager.h
@@ -105,6 +105,7 @@ class CompManager : public CwbCallback {
   DisplayError CheckEnforceSplit(Handle comp_handle, uint32_t new_refresh_rate);
   DppsControlInterface* GetDppsControlIntf();
   bool CheckResourceState(Handle display_ctx, bool *res_exhausted, HWDisplayAttributes attr);
+  DisplayError GetConcurrencyFps(DisplayConcurrencyType type, float *fps);
   bool IsRotatorSupportedFormat(LayerBufferFormat format);
   DisplayError SetDrawMethod(Handle display_ctx, const DisplayDrawMethod &draw_method);
   DisplayError FreeDemuraFetchResources(const uint32_t &display_id);

--- a/sdm/libs/core/display_virtual.cpp
+++ b/sdm/libs/core/display_virtual.cpp
@@ -73,6 +73,28 @@ DisplayError DisplayVirtual::Init() {
     DisplayBase::SetMaxMixerStages(max_mixer_stages);
   }
 
+  int value = 0;
+  Debug::Get()->GetProperty(DISABLE_MITIGATED_FPS, &value);
+  disable_mitigated_fps_ = (value == 1);
+  DLOGI("disable_mitigated_fps_: %d", disable_mitigated_fps_);
+
+  value = 0;
+  Debug::Get()->GetProperty(ENABLE_ASYNC_VDS_CREATION, &value);
+  async_vds_creation_ = (value == 1);
+  DLOGI("async_vds_creation: %d", async_vds_creation_);
+
+  return error;
+}
+
+DisplayError DisplayVirtual::Deinit() {
+  DisplayError error = DisplayBase::Deinit();
+  float fps = 0;
+  if (async_vds_creation_ && !disable_mitigated_fps_) {
+    comp_manager_->GetConcurrencyFps(DisplayConcurrencyType::kConcurrencyWfd, &fps);
+    if (fps != 0.0) {
+      event_handler_->NotifyFpsMitigation(fps, DisplayConcurrencyType::kConcurrencyWfd, false);
+    }
+  }
   return error;
 }
 
@@ -155,6 +177,15 @@ DisplayError DisplayVirtual::SetActiveConfig(DisplayConfigVariableInfo *variable
   if (error != kErrorNone) {
     return error;
   }
+
+  if (async_vds_creation_ && !disable_mitigated_fps_) {
+    float fps = 0;
+    comp_manager_->GetConcurrencyFps(DisplayConcurrencyType::kConcurrencyWfd, &fps);
+    if (fps != 0.0) {
+      event_handler_->NotifyFpsMitigation(fps, DisplayConcurrencyType::kConcurrencyWfd, true);
+    }
+  }
+
   default_clock_hz_ = cached_qos_data_.clock_hz;
 
   display_attributes_ = display_attributes;

--- a/sdm/libs/core/display_virtual.h
+++ b/sdm/libs/core/display_virtual.h
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2014 - 2020, The Linux Foundation. All rights reserved.
+* Copyright (c) 2014 - 2021, The Linux Foundation. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification, are permitted
 * provided that the following conditions are met:
@@ -76,6 +76,7 @@ class DisplayVirtual : public DisplayBase {
                  HWInfoInterface *hw_info_intf, BufferAllocator *buffer_allocator,
                  CompManager *comp_manager);
   virtual DisplayError Init();
+  virtual DisplayError Deinit();
   virtual DisplayError Prepare(LayerStack *layer_stack);
   virtual DisplayError GetNumVariableInfoConfigs(uint32_t *count);
   virtual DisplayError GetConfig(uint32_t index, DisplayConfigVariableInfo *variable_info);
@@ -116,6 +117,8 @@ class DisplayVirtual : public DisplayBase {
  protected:
   float set_max_lum_ = -1.0;
   float set_min_lum_ = -1.0;
+  bool async_vds_creation_ = false;
+  bool disable_mitigated_fps_ = false;
 };
 
 }  // namespace sdm


### PR DESCRIPTION
Bump vendor.qti.hardware.display.config to v5 to satisfy camera framework.
Cherry-pick necessary commits with interface instead of blind version bump
to prevent potential null ptr dereference.

Tested on: Nagara