### PR TITLE
[9.12.r1] sdm: Remove deprecated sync APIs

### DIFF
--- a/composer/hwc_buffer_sync_handler.cpp
+++ b/composer/hwc_buffer_sync_handler.cpp
@@ -107,16 +107,4 @@ void HWCBufferSyncHandler::GetSyncInfo(int fd, std::ostringstream *os) {
   }
 }
 
-DisplayError HWCBufferSyncHandler::SyncWait(int fd) {
-  // Deprecated.
-  assert(false);
-  return kErrorUndefined;
-}
-
-bool HWCBufferSyncHandler::IsSyncSignaled(int fd) {
-  // Deprecated.
-  assert(false);
-  return false;
-}
-
 }  // namespace sdm

--- a/composer/hwc_buffer_sync_handler.h
+++ b/composer/hwc_buffer_sync_handler.h
@@ -40,10 +40,8 @@ namespace sdm {
 
 class HWCBufferSyncHandler : public BufferSyncHandler {
  public:
-  virtual DisplayError SyncWait(int fd);
   virtual DisplayError SyncWait(int fd, int timeout);
   virtual DisplayError SyncMerge(int fd1, int fd2, int *merged_fd);
-  virtual bool IsSyncSignaled(int fd);
   virtual void GetSyncInfo(int fd, std::ostringstream *os);
 
  private:

--- a/sdm/include/core/buffer_sync_handler.h
+++ b/sdm/include/core/buffer_sync_handler.h
@@ -52,18 +52,6 @@ namespace sdm {
 */
 class BufferSyncHandler {
  public:
-  /*! @brief Method to wait for ouput buffer to be released.
-
-    @details This method waits for fd to be signaled by the producer/consumer with a default
-    timeout. It is the responsibility of the caller to close the file descriptor.
-
-    @param[in] fd file descriptor
-
-    @return \link DisplayError \endlink
-  */
-
-  virtual DisplayError SyncWait(int fd) = 0;
-
   /*! @brief Method to wait specified time for ouput buffer to be released.
 
     @details This method waits for fd to be signaled by the producer/consumer with a specified
@@ -90,17 +78,6 @@ class BufferSyncHandler {
  */
 
   virtual DisplayError SyncMerge(int fd1, int fd2, int *merged_fd) = 0;
-
-  /*! @brief Method to detect if sync fd is signaled
-
-    @details This method detects if sync fd is signaled. It is responsibility of the caller to
-    close file descriptor.
-
-    @param[in] fd file descriptor
-
-    @return True if fd has been signaled.
- */
-  virtual bool IsSyncSignaled(int fd) = 0;
 
   /*! @brief Method to get fence info associated to given file descriptor
 


### PR DESCRIPTION
APIs are marked as deprecated and using assert. Remove them.

Change-Id: I92b170174f66eee6aafd8bcaabb8d9aa6d7f7c21