### PR TITLE
[2.0.r1] qmaa: Do not import the non-existent libdebug namespace

### DIFF
--- a/qmaa/Android.bp
+++ b/qmaa/Android.bp
@@ -1,7 +1,6 @@
 soong_namespace {
     imports: [
         "vendor/qcom/opensource/display/sm8450",
-        "vendor/qcom/opensource/display/sm8450/libdebug",
     ],
 }
 composer_srcs = ["*.cpp"]


### PR DESCRIPTION
libdisplaydebug does not define its own namespace.

```
error: vendor/qcom/opensource/display/sm8450/qmaa/Android.bp:1:1: module
"soong_namespace": namespace vendor/qcom/opensource/display/sm8450/libdebug
does not exist; Some necessary modules may have been skipped by Soong.
Check if PRODUCT_SOURCE_ROOT_DIRS is pruning necessary Android.bp files.
Did you mean "vendor/qcom/opensource/display/sm8450"?
```