### PR TITLE
[2.0.r1] gralloc: Ignore format and unused-parameter warnings

### DIFF
--- a/gralloc/Android.bp
+++ b/gralloc/Android.bp
@@ -29,6 +29,7 @@ cc_library_shared {
         "-Wno-sign-conversion",
         "-Wno-unused-parameter",
         "-Wno-unused-variable",
+        "-Wno-format",
         "-Wno-implicit-fallthrough",
     ],
     srcs: [
@@ -74,6 +75,7 @@ cc_library_shared {
         "-Wno-sign-conversion",
         "-Wno-unused-variable",
         "-Wno-unused-parameter",
+        "-Wno-format",
     ],
     srcs: [
         "gr_allocator.cpp",
@@ -140,6 +142,7 @@ cc_library_shared {
         "-DLOG_TAG=\"qdgralloc\"",
         "-D__QTI_DISPLAY_GRALLOC__",
         "-Wno-sign-conversion",
+        "-Wno-unused-parameter",
     ],
     srcs: [
         "QtiMapper4.cpp",


### PR DESCRIPTION
Ignore format and unused-parameter compilation warnings.
The code is a bit messy and for the portability of our
patches we decided not to fix all the compilation warnings,
but to ignore them for the portability of the patches.